### PR TITLE
fix #1 Node Not Found: SubViewport

### DIFF
--- a/Control3D.gd
+++ b/Control3D.gd
@@ -74,6 +74,8 @@ func add_control_to_viewport():
 
 ##Sets the size of the [SubViewport]
 func set_viewport_size(s:Vector2):
+	if has_node('SubViewport') == false:
+		return
 	$SubViewport.size = s
 
 ##Calls clears the [SubViewport]s children then adds the new [Control] nodes

--- a/Control3D.gd
+++ b/Control3D.gd
@@ -40,9 +40,9 @@ func _ready() -> void:
 	var subViewport := SubViewport.new()
 	subViewport.name = "SubViewport"
 	subViewport.disable_3d = true
+	add_child(subViewport, true)
 	set_viewport_size(viewport_resolution)
 	if force_viewport_aspect_ratio: set_viewport_size(size*viewport_resolution_scale)
-	add_child(subViewport, true)
 	mesh = QuadMesh.new()
 	mesh.size = size
 	var mat := StandardMaterial3D.new()


### PR DESCRIPTION
`set_viewport_size` uses `$SubViewport` but at the point where it gets called, the node does not yet exist in the node tree (it gets added _after_).